### PR TITLE
Antivirus scanner fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,10 @@ FROM amazonlinux:2 AS build-clamav
 
 RUN yum update -y
 RUN amazon-linux-extras install epel -y
-RUN yum install -y cpio yum-utils zip openssl
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN yum install clamav clamd -y
 
-WORKDIR /tmp
-
-RUN yumdownloader -x \*i686 --archlist=x86_64 clamav clamav-lib clamav-update gnutls json-c libprelude libtasn1 nettle pcre2
-RUN rpm2cpio clamav-0*.rpm | cpio -idmv
-RUN rpm2cpio clamav-lib*.rpm | cpio -idmv
-RUN rpm2cpio clamav-update*.rpm | cpio -idmv
-RUN rpm2cpio gnutls*.rpm | cpio -idmv
-RUN rpm2cpio json-c*.rpm | cpio -idmv
-RUN rpm2cpio libprelude*.rpm | cpio -idmv
-RUN rpm2cpio libtasn1*.rpm | cpio -idmv
-RUN rpm2cpio nettle*.rpm | cpio -idmv
-RUN rpm2cpio pcre*.rpm | cpio -idmv
+COPY ./freshclam.conf /etc
+RUN freshclam
 
 FROM golang:1.17.6 AS build-env
 
@@ -38,12 +27,16 @@ ENV DOCKER_LAMBDA_STAY_OPEN=1
 ENV AWS_LAMBDA_FUNCTION_HANDLER=main
 ENV LD_LIBRARY_PATH=/var/task/lib
 
-COPY --from=build-clamav /tmp/usr/bin/clamscan /var/task/bin/clamscan
-COPY --from=build-clamav /tmp/usr/bin/freshclam /var/task/bin/freshclam
-COPY --from=build-clamav /tmp/usr/lib64 /var/task/lib
-
 COPY ./freshclam.conf /etc
-RUN mkdir -p /tmp/usr/clamav
-RUN /var/task/bin/freshclam
+COPY --from=build-clamav /usr/bin/clamscan /var/task/bin/clamscan
+COPY --from=build-clamav /usr/lib64/libclam* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libgnutls* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libhogweed* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libjson* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libnettle* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libpcre* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libprelude* /var/task/lib/
+COPY --from=build-clamav /usr/lib64/libtasn1* /var/task/lib/
+COPY --from=build-clamav /var/lib/clamav /var/lib/clamav
 
 COPY --from=build-env /go/bin/main /var/task/main

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,3 @@ services:
       retries: 3
       start_period: 30s
 
-
-volumes:
-  antivirus-build:

--- a/freshclam.conf
+++ b/freshclam.conf
@@ -1,4 +1,4 @@
 DatabaseMirror database.clamav.net
 CompressLocalDatabase yes
 ScriptedUpdates no
-DatabaseDirectory /tmp/usr/clamav
+DatabaseDirectory /var/lib/clamav

--- a/main_test.go
+++ b/main_test.go
@@ -125,7 +125,7 @@ func TestHandleEventPass(t *testing.T) {
 	mockS3.AssertExpectations(t)
 }
 
-func TestHandleEventAppendsTags(t *testing.T) {
+func TestHandleEventHandlesDuplicateTags(t *testing.T) {
 	downloader := new(mockDownloader)
 	downloader.On("Download", "my-bucket", "file-key").Return(nil)
 
@@ -138,9 +138,8 @@ func TestHandleEventAppendsTags(t *testing.T) {
 		{Key: aws.String("upload-source"), Value: aws.String("online")},
 	}, nil)
 	mockS3.On("PutObjectTagging", "my-bucket", "file-key", []*s3.Tag{
-		{Key: aws.String("VIRUS_SCAN"), Value: aws.String("okay")},
-		{Key: aws.String("upload-source"), Value: aws.String("online")},
 		{Key: aws.String("VIRUS_SCAN"), Value: aws.String("fail")},
+		{Key: aws.String("upload-source"), Value: aws.String("online")},
 	}).Return(nil)
 
 	l := &Lambda{

--- a/scanner.go
+++ b/scanner.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -9,7 +10,11 @@ type ClamAvScanner struct {
 }
 
 func (s *ClamAvScanner) ScanFile(path string) (bool, error) {
-	cmd := exec.Command("./bin/clamscan", path)
+	cmd := exec.Command("./bin/clamscan", "--stdout", "-d", "/var/lib/clamav", path)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok && exitError.ExitCode() == 1 {
 			return false, nil


### PR DESCRIPTION
A few fixes found when deploying the antivirus scanner
- Use a more standard ClamAV installation
- Ensure there's only one scan-status tag on each S3 object
- Write clamscan output to stdout so it can be reviewed in Lambda logs

For VEGA-1168 #minor