### PR TITLE
Move to smaller base image

### DIFF
--- a/cmd/opg-s3-antivirus-update/freshclam.go
+++ b/cmd/opg-s3-antivirus-update/freshclam.go
@@ -8,7 +8,7 @@ import (
 type Freshclam struct{}
 
 func (c *Freshclam) Update() error {
-	cmd := exec.Command("./bin/freshclam")
+	cmd := exec.Command("freshclam", "--config-file=/etc/freshclam.conf")
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout

--- a/cmd/opg-s3-antivirus-update/main.go
+++ b/cmd/opg-s3-antivirus-update/main.go
@@ -77,9 +77,10 @@ func (l *Lambda) uploadDefinitions() error {
 		}
 
 		input := &s3manager.UploadInput{
-			Bucket: aws.String(l.bucket),
-			Key:    aws.String(key),
-			Body:   file,
+			Bucket:               aws.String(l.bucket),
+			Key:                  aws.String(key),
+			Body:                 file,
+			ServerSideEncryption: aws.String("AES256"),
 		}
 
 		if _, err := l.uploader.Upload(input); err != nil {

--- a/cmd/opg-s3-antivirus-update/main_test.go
+++ b/cmd/opg-s3-antivirus-update/main_test.go
@@ -30,7 +30,7 @@ type mockUploader struct {
 }
 
 func (m *mockUploader) Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
-	args := m.Called(*input.Bucket, *input.Key, input.Body)
+	args := m.Called(*input.Bucket, *input.Key, input.Body, *input.ServerSideEncryption)
 	return nil, args.Error(0)
 }
 
@@ -85,7 +85,7 @@ func TestHandleEvent(t *testing.T) {
 		On("Update").Return(nil)
 
 	uploader.
-		On("Upload", "a-bucket", "a", mock.Anything).
+		On("Upload", "a-bucket", "a", mock.Anything, "AES256").
 		Run(func(args mock.Arguments) {
 			r := args[2].(io.Reader)
 			data, _ := io.ReadAll(r)
@@ -94,7 +94,7 @@ func TestHandleEvent(t *testing.T) {
 		Return(nil)
 
 	uploader.
-		On("Upload", "a-bucket", "b", mock.Anything).
+		On("Upload", "a-bucket", "b", mock.Anything, "AES256").
 		Run(func(args mock.Arguments) {
 			r := args[2].(io.Reader)
 			data, _ := io.ReadAll(r)
@@ -147,11 +147,11 @@ func TestHandleEventFirstRun(t *testing.T) {
 		On("Update").Return(nil)
 
 	uploader.
-		On("Upload", "a-bucket", "a", mock.Anything).
+		On("Upload", "a-bucket", "a", mock.Anything, "AES256").
 		Return(nil)
 
 	uploader.
-		On("Upload", "a-bucket", "b", mock.Anything).
+		On("Upload", "a-bucket", "b", mock.Anything, "AES256").
 		Return(nil)
 
 	response, err := l.HandleEvent(Event{})

--- a/cmd/opg-s3-antivirus/scanner.go
+++ b/cmd/opg-s3-antivirus/scanner.go
@@ -10,7 +10,7 @@ type ClamAvScanner struct {
 }
 
 func (s *ClamAvScanner) ScanFile(path string) (bool, error) {
-	cmd := exec.Command("./bin/clamscan", "--stdout", "-d", "/tmp/clamav", path)
+	cmd := exec.Command("clamscan", "--stdout", "-d", "/tmp/clamav", path)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       ANTIVIRUS_TAG_VALUE_PASS: ok
       ANTIVIRUS_TAG_VALUE_FAIL: infected
       ANTIVIRUS_DEFINITIONS_BUCKET: virus-definitions
+    volumes:
+      - "../.aws-lambda-rie:/aws-lambda"
+    entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
 
   antivirus-update-function:
     image: antivirus-update-function:latest
@@ -28,6 +31,9 @@ services:
       AWS_ACCESS_KEY_ID: localstack
       AWS_SECRET_ACCESS_KEY: localstack
       ANTIVIRUS_DEFINITIONS_BUCKET: virus-definitions
+    volumes:
+      - "../.aws-lambda-rie:/aws-lambda"
+    entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
 
   localstack:
     image: localstack/localstack:0.13
@@ -42,7 +48,7 @@ services:
       SERVICES: s3,lambda
       LAMBDA_EXECUTOR: docker
       LAMBDA_REMOVE_CONTAINERS: "true"
-      LAMBDA_FORWARD_URL: http://antivirus-function:9001
+      LAMBDA_FORWARD_URL: http://antivirus-function:8080
       DOCKER_HOST: unix:///var/run/docker.sock
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:4566 || exit 1"]

--- a/docker/opg-s3-antivirus-update/Dockerfile
+++ b/docker/opg-s3-antivirus-update/Dockerfile
@@ -1,10 +1,4 @@
-FROM amazonlinux:2 AS build-clamav
-
-RUN yum update -y &&\
-  amazon-linux-extras install epel -y &&\
-  yum install clamav clamd -y
-
-FROM golang:1.17.6 AS build-env
+FROM golang:1.17.7 AS build-env
 
 WORKDIR /app
 
@@ -17,24 +11,13 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus-update
 
-FROM lambci/lambda:go1.x
+FROM alpine:3.15
 
-ENV DOCKER_LAMBDA_WATCH=1
-ENV DOCKER_LAMBDA_STAY_OPEN=1
-ENV AWS_LAMBDA_FUNCTION_HANDLER=main
-ENV LD_LIBRARY_PATH=/var/task/lib
+RUN apk update && apk add --no-cache clamav
+
+RUN mkdir -p /tmp/clamav && chown -R clamav:clamav /tmp/clamav
 
 COPY ./freshclam.conf /etc
-COPY --from=build-clamav /usr/bin/freshclam /var/task/bin/freshclam
-COPY --from=build-clamav /usr/lib64/libclam* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libfreshclam* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libgnutls* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libhogweed* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libjson* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libltdl* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libnettle* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libpcre* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libprelude* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libtasn1* /var/task/lib/
-
 COPY --from=build-env /go/bin/main /var/task/main
+
+ENTRYPOINT [ "/var/task/main" ]

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -1,10 +1,4 @@
-FROM amazonlinux:2 AS build-clamav
-
-RUN yum update -y &&\
-  amazon-linux-extras install epel -y &&\
-  yum install clamav clamd -y
-
-FROM golang:1.17.6 AS build-env
+FROM golang:1.17.7 AS build-env
 
 WORKDIR /app
 
@@ -17,21 +11,10 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM lambci/lambda:go1.x
+FROM alpine:3.15
 
-ENV DOCKER_LAMBDA_WATCH=1
-ENV DOCKER_LAMBDA_STAY_OPEN=1
-ENV AWS_LAMBDA_FUNCTION_HANDLER=main
-ENV LD_LIBRARY_PATH=/var/task/lib
-
-COPY --from=build-clamav /usr/bin/clamscan /var/task/bin/clamscan
-COPY --from=build-clamav /usr/lib64/libclam* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libgnutls* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libhogweed* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libjson* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libnettle* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libpcre* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libprelude* /var/task/lib/
-COPY --from=build-clamav /usr/lib64/libtasn1* /var/task/lib/
+RUN apk update && apk add --no-cache clamav
 
 COPY --from=build-env /go/bin/main /var/task/main
+
+ENTRYPOINT [ "/var/task/main" ]

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -34,7 +34,7 @@ awslocal s3api put-bucket-policy \
     --bucket "uploads-bucket"
 
 awslocal lambda create-function \
-         --function-name antivirus \
+         --function-name function \
          --code ImageUri=antivirus-function:latest \
          --role arn:aws:iam::000000000:role/lambda-ex
 
@@ -42,7 +42,7 @@ echo '{
     "LambdaFunctionConfigurations": [
         {
             "Id": "bucket-av-scan",
-            "LambdaFunctionArn": "arn:aws:lambda:eu-west-1:000000000000:function:antivirus",
+            "LambdaFunctionArn": "arn:aws:lambda:eu-west-1:000000000000:function:function",
             "Events": [
                 "s3:ObjectCreated:Put"
             ]

--- a/test.sh
+++ b/test.sh
@@ -10,16 +10,17 @@ catch() {
 docker compose -f docker/docker-compose.yml up --wait localstack
 docker compose -f docker/docker-compose.yml exec -T localstack bash -c '. /scripts/wait/wait-until-s3-ready.sh'
 
-docker compose -f docker/docker-compose.yml exec -T localstack awslocal lambda invoke --endpoint http://antivirus-update-function:9001 --no-sign-request --function-name antivirus-update --payload '{}' /dev/stdout
+docker compose -f docker/docker-compose.yml exec -T localstack awslocal lambda invoke --endpoint http://antivirus-update-function:8080 --no-sign-request --function-name function --payload '{}' /dev/stdout
 docker compose -f docker/docker-compose.yml exec -T localstack awslocal s3api list-objects --bucket virus-definitions
 docker compose -f docker/docker-compose.yml restart antivirus-function
 
 sleep 10
 docker compose -f docker/docker-compose.yml exec -T localstack bash -c 'echo "Test file" | awslocal s3 cp - s3://uploads-bucket/valid.txt'
-docker compose -f docker/docker-compose.yml exec -T localstack bash -c 'echo "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" | awslocal s3 cp - s3://uploads-bucket/invalid.txt'
 
 docker compose -f docker/docker-compose.yml exec -T localstack bash -c '. /scripts/wait/wait-until-tagged.sh valid.txt'
 docker compose -f docker/docker-compose.yml exec -T localstack awslocal s3api get-object-tagging --bucket uploads-bucket --key valid.txt | jq -e '(.TagSet[] | select(.Key == "virus-scan-status")).Value == "ok"'
+
+docker compose -f docker/docker-compose.yml exec -T localstack bash -c 'echo "X5O!P%@AP[4\PZX54(P^)7CC)7}\$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!\$H+H*" | awslocal s3 cp - s3://uploads-bucket/invalid.txt'
 
 docker compose -f docker/docker-compose.yml exec -T localstack bash -c '. /scripts/wait/wait-until-tagged.sh invalid.txt'
 docker compose -f docker/docker-compose.yml exec -T localstack awslocal s3api get-object-tagging --bucket uploads-bucket --key invalid.txt | jq -e '(.TagSet[] | select(.Key == "virus-scan-status")).Value == "infected"'


### PR DESCRIPTION
Use alpine as a base image, and install clamav properly so that it's just available on PATH. This led to a few changes to how we call `clamscan` and `freshclam`.

Without lambci, we now need `aws-lambda-rie` to provide the Lambda runtime environment (i.e. the HTTP API). Because this is just needed for local dev, mount it rather than installing on the image directly.

`aws-lambda-rie` causes two restrictions:
- The function name must be "function". There's [a PR to make this configurable](https://github.com/aws/aws-lambda-runtime-interface-emulator/pull/46), but AWS don't seem keen
- It can only handle one invokation at a time, so we can't upload the second test file (and therefore invoke the Lamdba) until the first is finished

#minor