### PR TITLE
Try using clamd instead of clamscan

### DIFF
--- a/clamd.conf
+++ b/clamd.conf
@@ -1,0 +1,3 @@
+DatabaseDirectory /tmp/clamav
+PidFile /tmp/clamav/clamd.pid
+LocalSocket /tmp/clamav/clamd.sock

--- a/cmd/opg-s3-antivirus/main.go
+++ b/cmd/opg-s3-antivirus/main.go
@@ -44,6 +44,7 @@ type Downloader interface {
 }
 
 type Scanner interface {
+	StartDaemon() error
 	ScanFile(path string) (bool, error)
 }
 
@@ -199,6 +200,11 @@ func main() {
 	err := l.downloadDefinitions("/tmp/clamav", os.Getenv("ANTIVIRUS_DEFINITIONS_BUCKET"), []string{"bytecode.cvd", "daily.cvd", "freshclam.dat", "main.cvd"})
 	if err != nil {
 		log.Printf("downloading new definitions failed: %v", err)
+	}
+
+	err = l.scanner.StartDaemon()
+	if err != nil {
+		log.Printf("error starting damon: %v", err)
 	}
 
 	lambda.Start(l.HandleEvent)

--- a/cmd/opg-s3-antivirus/main_test.go
+++ b/cmd/opg-s3-antivirus/main_test.go
@@ -28,6 +28,11 @@ type mockScanner struct {
 	mock.Mock
 }
 
+func (m *mockScanner) StartDaemon() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func (m *mockScanner) ScanFile(path string) (bool, error) {
 	args := m.Called(path)
 	return args.Bool(0), args.Error(1)

--- a/cmd/opg-s3-antivirus/scanner.go
+++ b/cmd/opg-s3-antivirus/scanner.go
@@ -9,8 +9,21 @@ import (
 type ClamAvScanner struct {
 }
 
+func (s *ClamAvScanner) StartDaemon() (error) {
+	cmd := exec.Command("clamd", "--config-file", "/etc/clamd.conf")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to scan file, %w", err)
+	}
+
+	return nil
+}
+
 func (s *ClamAvScanner) ScanFile(path string) (bool, error) {
-	cmd := exec.Command("clamscan", "--stdout", "-d", "/tmp/clamav", path)
+	cmd := exec.Command("clamdscan", "--config-file", "/etc/clamd.conf", "--stdout", path)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -15,6 +15,7 @@ FROM alpine:3.15
 
 RUN apk update && apk add --no-cache clamav
 
+COPY ./clamd.conf /etc
 COPY --from=build-env /go/bin/main /var/task/main
 
 ENTRYPOINT [ "/var/task/main" ]


### PR DESCRIPTION
This change increases the startup time, but massively reduces the invocation time.

From trialling in AWS, the first execution of the Lambda might take 100000ms (1m40s) but if another one occurs before it's shutdown (within 5 minutes?) it takes less than 200ms (0.2s).

So if we get frequent-enough events, this could be extremely cost effective. But if we receive infrequent documents then it'll cost a lot more.