### PR TITLE
URL-decode S3 object key

### DIFF
--- a/cmd/opg-s3-antivirus/main.go
+++ b/cmd/opg-s3-antivirus/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -141,7 +142,12 @@ func (l *Lambda) tagFile(bucket string, key string, status string) error {
 
 func (l *Lambda) HandleEvent(event ObjectCreatedEvent) (MyResponse, error) {
 	bucketName := event.Records[0].S3.Bucket.Name
-	objectKey := event.Records[0].S3.Object.Key
+	objectKey, err := url.QueryUnescape(event.Records[0].S3.Object.Key)
+
+	if err != nil {
+		return MyResponse{}, fmt.Errorf("failed to get object key: %w", err)
+	}
+
 	log.Printf("downloading %s from %s", objectKey, bucketName)
 
 	f, err := os.CreateTemp("/tmp", "file")

--- a/cmd/opg-s3-antivirus/main_test.go
+++ b/cmd/opg-s3-antivirus/main_test.go
@@ -61,7 +61,7 @@ func createTestEvent() ObjectCreatedEvent {
 	event := ObjectCreatedEvent{}
 	eventRecord := EventRecord{}
 	eventRecord.S3.Bucket.Name = "my-bucket"
-	eventRecord.S3.Object.Key = "file-key"
+	eventRecord.S3.Object.Key = "file%2Dkey"
 	event.Records = append(event.Records, eventRecord)
 
 	return event


### PR DESCRIPTION
The S3 object key is URL-encoded, so we must decode it before making requests to S3.

#patch