### PR TITLE
Delete file after scanning

### DIFF
--- a/cmd/opg-s3-antivirus/main.go
+++ b/cmd/opg-s3-antivirus/main.go
@@ -154,6 +154,7 @@ func (l *Lambda) HandleEvent(event ObjectCreatedEvent) (MyResponse, error) {
 	if err != nil {
 		return MyResponse{}, fmt.Errorf("failed to create file: %w", err)
 	}
+	defer os.Remove(f.Name())
 	defer f.Close()
 
 	if err := l.downloadFile(f, bucketName, objectKey); err != nil {


### PR DESCRIPTION
Otherwise `/tmp` fills up and the Lambda stops working

#patch