### PR TITLE
Delete incomplete veracode scans

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         filepath: './package.zip'
         vid: '${{ secrets.CYBERSECURITY_VERACODE_API_ID }}'
         vkey: '${{ secrets.CYBERSECURITY_VERACODE_API_KEY }}'
+        deleteIncompleteScan: true
 
     - name: Cleanup
       run: |


### PR DESCRIPTION
So that we can merge PRs close to each other and not fall into conflicts