### PR TITLE
MLPAB-2085 - Use amazon linux lambda base image for faster initialisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ scan: setup-directories
 	docker compose run --rm trivy image --format table --exit-code 0 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest
 	docker compose run --rm trivy image --format sarif --output /test-results/trivy.sarif --exit-code 1 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest
 
+check-clam:
+	docker compose up s3-antivirus -d
+	docker compose exec -T s3-antivirus bash -c 'clamdscan --version'
+	docker compose exec -T s3-antivirus bash -c 'clamd --config-file "/etc/clamd.conf"'
+
 acceptance-test:
 	docker compose up --wait localstack
 	docker compose exec -T localstack bash -c '. /scripts/wait/wait-until-s3-ready.sh'

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ scan: setup-directories
 
 check-clam:
 	docker compose up s3-antivirus -d
+	docker compose exec -T s3-antivirus bash -c 'yum list available clam\* libcurl\* libxml2\* openssl\*'
 	docker compose exec -T s3-antivirus bash -c 'clamdscan --version'
 	docker compose exec -T s3-antivirus bash -c 'clamd --config-file "/etc/clamd.conf"'
 

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,19 +11,18 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM public.ecr.aws/lambda/provided:al2
+FROM public.ecr.aws/lambda/provided:al2023
 
 ENV PATH="${PATH}:/usr/sbin"
 
-RUN yum update -y && yum install -y clamav clamd && yum clean all
+RUN dnf update && dnf --best install -y clamav clamd && dnf clean all
 
-RUN yum update -y && \
-    yum upgrade -y \
+RUN dnf update && \
+    dnf upgrade \
     libcurl \
     libxml2 \
     openssl && \
-    yum clean all
-
+    dnf clean all
 
 COPY ./clamd.conf /etc
 COPY --from=build-env /go/bin/main /var/task/main

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,16 +11,19 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM public.ecr.aws/lambda/provided:al2023
+FROM public.ecr.aws/lambda/provided:al2
 
-RUN dnf update && dnf --best install -y clamav && dnf clean all
+ENV PATH="${PATH}:/usr/sbin"
 
-RUN dnf update && \
-    dnf upgrade \
+RUN yum update -y && yum install -y clamav clamd && yum clean all
+
+RUN yum update -y && \
+    yum upgrade -y \
     libcurl \
     libxml2 \
     openssl && \
-    dnf clean all
+    yum clean all
+
 
 COPY ./clamd.conf /etc
 COPY --from=build-env /go/bin/main /var/task/main

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM public.ecr.aws/lambda/provided:al2023-x86_64
+FROM public.ecr.aws/lambda/provided:al2023.2024.04.29.12-x86_64
 
 ENV PATH="${PATH}:/usr/sbin"
 

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,18 +11,19 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM public.ecr.aws/lambda/provided:al2023.2024.04.29.12-x86_64
+FROM public.ecr.aws/lambda/provided:al2
 
 ENV PATH="${PATH}:/usr/sbin"
 
-RUN dnf update && dnf --best install -y clamav clamd && dnf clean all
+RUN yum update -y && yum install -y clamav clamd && yum clean all
 
-RUN dnf update && \
-    dnf upgrade \
+RUN yum update -y && \
+    yum upgrade -y \
     libcurl \
     libxml2 \
     openssl && \
-    dnf clean all
+    yum clean all
+
 
 COPY ./clamd.conf /etc
 COPY --from=build-env /go/bin/main /var/task/main

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -15,13 +15,13 @@ FROM public.ecr.aws/lambda/provided:al2
 
 ENV PATH="${PATH}:/usr/sbin"
 
-RUN yum update -y && yum install -y clamav clamd && yum clean all
+RUN yum update -y && yum install -y clamav-0.103.9-1.amzn2.0.2 clamd-0.103.9-1.amzn2.0.2 && yum clean all
 
 RUN yum update -y && \
     yum upgrade -y \
-    libcurl \
-    libxml2 \
-    openssl && \
+    libcurl-8.3.0-1.amzn2.0.6 \
+    libxml2-2.9.1-6.amzn2.5.13 \
+    openssl-1:1.0.2k-24.amzn2.0.12 && \
     yum clean all
 
 

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM public.ecr.aws/lambda/provided:al2023
+FROM public.ecr.aws/lambda/provided:al2023-x86_64
 
 ENV PATH="${PATH}:/usr/sbin"
 

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -11,18 +11,16 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/bin/main ./cmd/opg-s3-antivirus
 
-FROM alpine:3
+FROM public.ecr.aws/lambda/provided:al2023
 
-RUN apk update && apk add --no-cache clamav
+RUN dnf update && dnf --best install -y clamav && dnf clean all
 
-RUN apk update && \
-    apk upgrade \
-    libcrypto3 \
+RUN dnf update && \
+    dnf upgrade \
     libcurl \
-    libssl3 \
     libxml2 \
     openssl && \
-    rm -rf /var/cache/apk/*
+    dnf clean all
 
 COPY ./clamd.conf /etc
 COPY --from=build-env /go/bin/main /var/task/main


### PR DESCRIPTION
# Purpose

Use amazon base image to test faster cold start initialisation times as advised by AWS support and https://aws.amazon.com/blogs/compute/optimizing-lambda-functions-packaged-as-container-images/

# Approach

- replace alpine with Amazon Linux 2 lambda image
- add `/usr/sbin` to path so `clamd` can be called

I also tried using the latest Amazon Linux 2023 lambda image but there were none without vulnerabilities at the time. This would have been a route to longer support. (see https://endoflife.date/amazon-linux)

(might attempt to pin a version of ClamAV)

# Learning

- https://docs.aws.amazon.com/linux/al2023/ug/package-management.html
- https://docs.clamav.net/manual/Installing/Packages.html
- https://docs.aws.amazon.com/lambda/latest/dg/go-image.html
- https://gallery.ecr.aws/lambda/provided