### PR TITLE
SP-2158 - Update clamav package ref, ignore Lambda RIE Vuln #minor

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,3 @@
-# Ignore AWS Go SDK Vulnerability as it's not fixed yet.
-CVE-2020-8911
-CVE-2020-8912
+# Ignore AWS Lambda Runtime stdlib vuln.
+CVE-2024-24789
+CVE-2024-24790

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   localstack:
     image: localstack/localstack:3.4
-    depends_on: [s3-antivirus, s3-antivirus-update]
+    depends_on: [ s3-antivirus, s3-antivirus-update ]
     volumes:
       - "./scripts/localstack/init:/etc/localstack/init/ready.d"
       - "./scripts/localstack/wait:/scripts/wait"
@@ -42,7 +42,7 @@ services:
     environment:
       AWS_DEFAULT_REGION: eu-west-1
     healthcheck:
-      test: ["CMD-SHELL", "curl http://localhost:4566 || exit 1"]
+      test: [ "CMD-SHELL", "curl http://localhost:4566 || exit 1" ]
       interval: 15s
       timeout: 10s
       retries: 3
@@ -79,3 +79,4 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./.trivy-cache:/root/.cache
       - ./test-results:/test-results
+      - ./.trivyignore:/.trivyignore

--- a/docker/opg-s3-antivirus/Dockerfile
+++ b/docker/opg-s3-antivirus/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3 AS build-env
+FROM golang:1.22-alpine AS build-env
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ FROM public.ecr.aws/lambda/provided:al2
 
 ENV PATH="${PATH}:/usr/sbin"
 
-RUN yum update -y && yum install -y clamav-0.103.9-1.amzn2.0.2 clamd-0.103.9-1.amzn2.0.2 && yum clean all
+RUN yum update -y && yum install -y clamav-0.103.11-1.amzn2.0.1 clamd-0.103.11-1.amzn2.0.1 && yum clean all
 
 RUN yum update -y && \
     yum upgrade -y \


### PR DESCRIPTION
# Purpose

Update the clamav package reference to fix build. Ignore base container vuln in Lambda RIE.

Fixes: SP-2158
