### PR TITLE
MLPAB-2432 - Fix failing path to live

### DIFF
--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -6,6 +6,9 @@ on:
       tag:
         description: "Semver Tag"
         value: ${{ jobs.create_tag.outputs.tag }}
+      timestamp:
+        description: "timestamp"
+        value: ${{ jobs.create_tag.outputs.tag }}
 
 jobs:
   create_tag:
@@ -35,5 +38,9 @@ jobs:
       - name: Post tag to summary
         run: |
           echo "Tag: ${{ steps.bump_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+      - name: Set Timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +"%Y%m%d%H%M%S")" >> "$GITHUB_OUTPUT"
     outputs:
       tag: ${{ steps.bump_version.outputs.tag }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -27,7 +27,7 @@ jobs:
         uses: anothrNick/github-tag-action@1.70.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BUMP: minor
+          DEFAULT_BUMP: patch
           PRERELEASE: true
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -32,6 +32,7 @@ jobs:
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true
+          FORCE_WITHOUT_CHANGES: true
       - name: Post tag to summary
         run: |
           echo "Tag: ${{ steps.bump_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -32,7 +32,6 @@ jobs:
           PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
           RELEASE_BRANCHES: main
           WITH_V: true
-          FORCE_WITHOUT_CHANGES: true
       - name: Post tag to summary
         run: |
           echo "Tag: ${{ steps.bump_version.outputs.tag }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/create-tags.yml
+++ b/.github/workflows/create-tags.yml
@@ -8,7 +8,7 @@ on:
         value: ${{ jobs.create_tag.outputs.tag }}
       timestamp:
         description: "timestamp"
-        value: ${{ jobs.create_tag.outputs.tag }}
+        value: ${{ jobs.create_tag.outputs.timestamp }}
 
 jobs:
   create_tag:

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -64,6 +64,10 @@ jobs:
         with:
           registries: 311462405659
 
+      - name: Set Timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +"%Y%m%d%H%M%S")" >> "$GITHUB_OUTPUT"
+
       - name: Push Function Container
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -73,6 +77,7 @@ jobs:
           if ${{ github.ref == 'refs/heads/main' }} ; then
             printf "Pushing main branch to ECR\n"
             docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{inputs.tag}}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{inputs.tag}}-${{ steps.timestamp.outputs.timestamp }}
             # We want all of the tags pushed
             docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
           else
@@ -89,6 +94,7 @@ jobs:
             printf "Pushing main branch to ECR\n"
             # We want all of the tags pushed
             docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{inputs.tag}}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{inputs.tag}}-${{ steps.timestamp.outputs.timestamp }}
             docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
           else
             docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:${{inputs.tag}}

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -7,6 +7,10 @@ on:
         description: "Semver Tag"
         required: true
         type: string
+      timestamp:
+        description: "timestamp"
+        required: false
+        type: string
     secrets:
       aws_access_key_id_actions:
         description: 'AWS Access Key'
@@ -64,24 +68,20 @@ jobs:
         with:
           registries: 311462405659
 
-      - name: Set Timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +"%Y%m%d%H%M%S")" >> "$GITHUB_OUTPUT"
-
       - name: Push Function Container
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: s3-antivirus
         run: |
-          docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:${{inputs.tag}}
+          docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:${{ inputs.tag }}
           if ${{ github.ref == 'refs/heads/main' }} ; then
             printf "Pushing main branch to ECR\n"
-            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{inputs.tag}}
-            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{inputs.tag}}-${{ steps.timestamp.outputs.timestamp }}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{ inputs.tag }}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:main-${{ inputs.tag }}-${{ inputs.timestamp }}
             # We want all of the tags pushed
             docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
           else
-            docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:${{inputs.tag}}
+            docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus:${{ inputs.tag }}
           fi
 
       - name: Push Update Function Container
@@ -89,13 +89,13 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: s3-antivirus-update
         run: |
-          docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:${{inputs.tag}}
+          docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:${{ inputs.tag }}
           if ${{ github.ref == 'refs/heads/main' }}; then
             printf "Pushing main branch to ECR\n"
             # We want all of the tags pushed
-            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{inputs.tag}}
-            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{inputs.tag}}-${{ steps.timestamp.outputs.timestamp }}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{ inputs.tag }}
+            docker tag 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:latest 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:main-${{ inputs.tag }}-${{ inputs.timestamp }}
             docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
           else
-            docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:${{inputs.tag}}
+            docker push 311462405659.dkr.ecr.eu-west-1.amazonaws.com/s3-antivirus-update:${{ inputs.tag }}
           fi

--- a/.github/workflows/lambda-zip-release.yml
+++ b/.github/workflows/lambda-zip-release.yml
@@ -7,7 +7,7 @@ on:
         description: "Semver Tag"
         required: true
         type: string
-      Timestamp:
+      timestamp:
         description: "timestamp"
         required: true
         type: string

--- a/.github/workflows/lambda-zip-release.yml
+++ b/.github/workflows/lambda-zip-release.yml
@@ -7,6 +7,10 @@ on:
         description: "Semver Tag"
         required: true
         type: string
+      Timestamp:
+        description: "timestamp"
+        required: true
+        type: string
 
 jobs:
   release-zips:
@@ -21,8 +25,8 @@ jobs:
         with:
           draft: ${{ github.ref != 'refs/heads/main' }}
           prerelease: ${{ github.ref != 'refs/heads/main' }}
-          release_name: ${{ inputs.tag }}-${{ steps.timestamp.outputs.timestamp }}
-          tag_name: ${{ inputs.tag }}-${{ steps.timestamp.outputs.timestamp }}
+          release_name: ${{ inputs.tag }}-${{ input.timestamp }}
+          tag_name: ${{ inputs.tag }}-${{ input.timestamp }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/lambda-zip-release.yml
+++ b/.github/workflows/lambda-zip-release.yml
@@ -12,14 +12,17 @@ jobs:
   release-zips:
     runs-on: ubuntu-latest
     steps:
+      - name: Set Timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +"%Y%m%d%H%M%S")" >> "$GITHUB_OUTPUT"
       - name: release
         uses: actions/create-release@v1
         id: create_release
         with:
           draft: ${{ github.ref != 'refs/heads/main' }}
           prerelease: ${{ github.ref != 'refs/heads/main' }}
-          release_name: ${{ inputs.tag }}
-          tag_name: ${{ inputs.tag }}
+          release_name: ${{ inputs.tag }}-${{ steps.timestamp.outputs.timestamp }}
+          tag_name: ${{ inputs.tag }}-${{ steps.timestamp.outputs.timestamp }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/lambda-zip-release.yml
+++ b/.github/workflows/lambda-zip-release.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           draft: ${{ github.ref != 'refs/heads/main' }}
           prerelease: ${{ github.ref != 'refs/heads/main' }}
-          release_name: ${{ inputs.tag }}-${{ input.timestamp }}
-          tag_name: ${{ inputs.tag }}-${{ input.timestamp }}
+          release_name: ${{ inputs.tag }}-${{ inputs.timestamp }}
+          tag_name: ${{ inputs.tag }}-${{ inputs.timestamp }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/tags-push.yml
+++ b/.github/workflows/tags-push.yml
@@ -7,6 +7,10 @@ on:
         description: "Semver Tag"
         required: true
         type: string
+      timestamp:
+        description: "timestamp"
+        required: true
+        type: string
     secrets:
       aws_access_key_id_actions:
         description: 'AWS Access Key'
@@ -50,4 +54,4 @@ jobs:
 
       - name: Push Tag to Parameter Store
         run: |
-          aws ssm put-parameter --name "/opg-s3-antivirus/zip-version-main" --type "String" --value "${{ inputs.tag }}" --overwrite --region=eu-west-1
+          aws ssm put-parameter --name "/opg-s3-antivirus/zip-version-main" --type "String" --value "${{ inputs.tag }}-${{ inputs.timestamp }}" --overwrite --region=eu-west-1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,6 +52,7 @@ jobs:
     needs: ['create-tag', 'build', 'unit-test', 'code-test', 'acceptance-test']
     with:
       tag: ${{ needs.create-tag.outputs.tag }}
+      timestamp: ${{ needs.create-tag.outputs.timestamp }}
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}
@@ -68,6 +69,7 @@ jobs:
     needs: ['create-tag', 'zip-lambda-build']
     with:
       tag: ${{ needs.create-tag.outputs.tag }}
+      timestamp: ${{ needs.create-tag.outputs.timestamp }}
 
   push-tags:
     name: Push Tags
@@ -76,6 +78,7 @@ jobs:
     uses: ./.github/workflows/tags-push.yml
     with:
       tag: ${{ needs.create-tag.outputs.tag }}
+      timestamp: ${{ needs.create-tag.outputs.timestamp }}
     secrets:
       aws_access_key_id_actions: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
       aws_secret_access_key_actions: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}


### PR DESCRIPTION
# Purpose

Default branch workflow has been failing to increment tags, which the tag actions returning "No new commits since previous tag. Skipping...". This means that new docker images have been replacing `v0.601.0` in the docker repository, but new releases for zip versions can't be created.

The approach we are taking is to include a timestamp to the path to live tags (and additional tag with semver-timestamp format) for docker images and zip releases

Fixes: MLPAB-2432

## Approach

- Create a timestamp in tags job
- pass timestamp into push and release jobs


## Learning

- https://github.com/anothrNick/github-tag-action
